### PR TITLE
B3 id conversion

### DIFF
--- a/lib/ddtrace/distributed_tracing/headers/b3.rb
+++ b/lib/ddtrace/distributed_tracing/headers/b3.rb
@@ -13,8 +13,8 @@ module Datadog
           return if context.nil?
 
           # DEV: We need these to be hex encoded
-          env[B3_HEADER_TRACE_ID] = context.trace_id.to_s(16)
-          env[B3_HEADER_SPAN_ID] = context.span_id.to_s(16)
+          env[B3_HEADER_TRACE_ID] = format(ID_FORMAT_STR, context.trace_id)
+          env[B3_HEADER_SPAN_ID] = format(ID_FORMAT_STR, context.span_id)
 
           unless context.sampling_priority.nil?
             sampling_priority = DistributedTracing::Headers::Helpers.clamp_sampling_priority(context.sampling_priority)

--- a/lib/ddtrace/distributed_tracing/headers/b3_single.rb
+++ b/lib/ddtrace/distributed_tracing/headers/b3_single.rb
@@ -18,7 +18,7 @@ module Datadog
           # DEV: `{SamplingState}` and `{ParentSpanId`}` are optional
 
           # DEV: We need these to be hex encoded
-          header = "#{context.trace_id.to_s(16)}-#{context.span_id.to_s(16)}"
+          header = "#{format(ID_FORMAT_STR, context.trace_id)}-#{format(ID_FORMAT_STR, context.span_id)}"
 
           unless context.sampling_priority.nil?
             sampling_priority = DistributedTracing::Headers::Helpers.clamp_sampling_priority(context.sampling_priority)

--- a/lib/ddtrace/ext/distributed.rb
+++ b/lib/ddtrace/ext/distributed.rb
@@ -28,6 +28,8 @@ module Datadog
       GRPC_METADATA_PARENT_ID = 'x-datadog-parent-id'.freeze
       GRPC_METADATA_SAMPLING_PRIORITY = 'x-datadog-sampling-priority'.freeze
       GRPC_METADATA_ORIGIN = 'x-datadog-origin'.freeze
+
+      ID_FORMAT_STR = '%016x'.freeze
     end
   end
 end

--- a/spec/ddtrace/distributed_tracing/headers/b3_single_spec.rb
+++ b/spec/ddtrace/distributed_tracing/headers/b3_single_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3Single do
     "http-#{name}".upcase!.tr('-', '_')
   end
 
+  def format_id(id)
+    format(Datadog::Ext::DistributedTracing::ID_FORMAT_STR, id)
+  end
+
   context '#inject!' do
     subject(:env) { {} }
     before(:each) { described_class.inject!(context, env) }
@@ -33,7 +37,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3Single do
                              span_id: 20000)
       end
 
-      it { is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE => '2710-4e20') }
+      it { is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE => "#{format_id(10000)}-#{format_id(20000)}") }
 
       [
         [-1, 0],
@@ -48,7 +52,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3Single do
                                  sampling_priority: value)
           end
 
-          it { is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE => "c350-ea60-#{expected}") }
+          it { is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE => "#{format_id(50000)}-#{format_id(60000)}-#{expected}") }
         end
       end
 
@@ -59,7 +63,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3Single do
                                origin: 'synthetics')
         end
 
-        it { is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE => '15f90-186a0') }
+        it { is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE => "#{format_id(90000)}-#{format_id(100000)}") }
       end
     end
   end
@@ -73,7 +77,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3Single do
     end
 
     context 'with trace_id and span_id' do
-      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => '15f90-186a0' } }
+      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => "#{format_id(90000)}-#{format_id(100000)}" } }
 
       it { expect(context.trace_id).to eq(90000) }
       it { expect(context.span_id).to eq(100000) }
@@ -81,14 +85,14 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3Single do
       it { expect(context.origin).to be_nil }
 
       context 'with sampling priority' do
-        let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => '15f90-186a0-1' } }
+        let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => "#{format_id(90000)}-#{format_id(100000)}-1" } }
         it { expect(context.trace_id).to eq(90000) }
         it { expect(context.span_id).to eq(100000) }
         it { expect(context.sampling_priority).to eq(1) }
         it { expect(context.origin).to be_nil }
 
         context 'with parent_id' do
-          let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => '15f90-186a0-1-4e20' } }
+          let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => "#{format_id(90000)}-#{format_id(100000)}-1-#{format_id(20000)}" } }
           it { expect(context.trace_id).to eq(90000) }
           it { expect(context.span_id).to eq(100000) }
           it { expect(context.sampling_priority).to eq(1) }
@@ -98,7 +102,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3Single do
     end
 
     context 'with trace_id' do
-      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => '15f90' } }
+      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SINGLE) => format_id(90000) } }
       it { is_expected.to be_nil }
     end
   end

--- a/spec/ddtrace/distributed_tracing/headers/b3_spec.rb
+++ b/spec/ddtrace/distributed_tracing/headers/b3_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
     "http-#{name}".upcase!.tr('-', '_')
   end
 
+  def format_id(id)
+    format(Datadog::Ext::DistributedTracing::ID_FORMAT_STR, id)
+  end
+
   context '#inject!' do
     subject(:env) { {} }
     before(:each) { described_class.inject!(context, env) }
@@ -29,8 +33,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
       end
 
       it do
-        is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID => 10000.to_s(16),
-                          Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID => 20000.to_s(16))
+        is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID => format_id(10000),
+                          Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID => format_id(20000))
       end
 
       [
@@ -47,8 +51,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
           end
 
           it do
-            is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID => 50000.to_s(16),
-                              Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID => 60000.to_s(16),
+            is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID => format_id(50000),
+                              Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID => format_id(60000),
                               Datadog::Ext::DistributedTracing::B3_HEADER_SAMPLED => expected.to_s)
           end
         end
@@ -62,8 +66,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
         end
 
         it do
-          is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID => 90000.to_s(16),
-                            Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID => 100000.to_s(16))
+          is_expected.to eq(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID => format_id(90000),
+                            Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID => format_id(100000))
         end
       end
     end
@@ -79,8 +83,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
 
     context 'with trace_id and span_id' do
       let(:env) do
-        { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => 10000.to_s(16),
-          env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => 20000.to_s(16) }
+        { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => format_id(10000),
+          env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => format_id(20000) }
       end
 
       it { expect(context.trace_id).to eq(10000) }
@@ -90,8 +94,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
 
       context 'with sampling priority' do
         let(:env) do
-          { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => 10000.to_s(16),
-            env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => 20000.to_s(16),
+          { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => format_id(10000),
+            env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => format_id(20000),
             env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SAMPLED) => '1' }
         end
 
@@ -103,8 +107,8 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
 
       context 'with origin' do
         let(:env) do
-          { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => 10000.to_s(16),
-            env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => 20000.to_s(16),
+          { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => format_id(10000),
+            env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => format_id(20000),
             env_header(Datadog::Ext::DistributedTracing::HTTP_HEADER_ORIGIN) => 'synthetics' }
         end
 
@@ -116,7 +120,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
     end
 
     context 'with span_id' do
-      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => 10000.to_s(16) } }
+      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_SPAN_ID) => format_id(10000) } }
       it { is_expected.to be_nil }
     end
 
@@ -126,7 +130,7 @@ RSpec.describe Datadog::DistributedTracing::Headers::B3 do
     end
 
     context 'with trace_id' do
-      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => 10000.to_s(16) } }
+      let(:env) { { env_header(Datadog::Ext::DistributedTracing::B3_HEADER_TRACE_ID) => format_id(10000) } }
       it { is_expected.to be_nil }
     end
   end


### PR DESCRIPTION
The PR updates ls-trace to represent trace and span ids as 16 hex digits as per the [b3 spec](https://github.com/openzipkin/b3-propagation#traceid-1) for both multi and single header propagation.

cc: @ishg 